### PR TITLE
refactor: move broadcasting logic to separate function

### DIFF
--- a/test_broadcasting.py
+++ b/test_broadcasting.py
@@ -1,0 +1,43 @@
+from smolgrad import Tensor
+import numpy as np
+import torch
+
+# Simple broadcasting test (forwards and backwards)
+
+arr1 = np.array([1, 2, 3, 4, 5]).astype(np.float32)
+arr2 = np.broadcast_to(np.array([1, 2, 3, 4, 5]), (5, 5)).astype(np.float32)
+a = Tensor(
+    arr1,
+    requires_grad=True
+)
+
+atorch = torch.tensor(arr1, requires_grad=True)
+
+b = Tensor(
+    arr2,
+    requires_grad=True
+)
+
+btorch = torch.tensor(arr2, requires_grad=True)
+
+
+def test_broadcasting(fn):
+    x = fn(a, b)
+    xtorch = fn(atorch, btorch)
+    x.sum().backward()
+    xtorch.sum().backward()
+
+    assert np.allclose(x.data, xtorch.data.numpy())
+    assert np.allclose(a.grad, atorch.grad.numpy())
+    assert np.allclose(b.grad, btorch.grad.numpy())
+    print("All tests pass")
+    # clear the gradients
+    a._reset_grad()
+    b._reset_grad()
+    atorch.grad.zero_()
+    btorch.grad.zero_()
+
+test_broadcasting(lambda x, y: x + y)
+test_broadcasting(lambda x, y: x - y)
+test_broadcasting(lambda x, y: x * y)
+test_broadcasting(lambda x, y: x / y)


### PR DESCRIPTION
What I mentioned in https://github.com/smolorg/smolgrad/issues/1. Can be added to matmul also. Also added some tests for some binary ops and it seems to work fine, altough in my opinion it might be good to add a test folder with different cases for every op and some 'formal' tests to verify everything works the same way as pytorch. Let me know what you think (any comment is welcome)